### PR TITLE
Fix release: add explicit module names for Maven Central

### DIFF
--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -11,6 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>validation</artifactId>
+    <name>Octopus WL Validation</name>
 
     <build>
         <plugins>

--- a/wl-tool/pom.xml
+++ b/wl-tool/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>wl-tool</artifactId>
+    <name>Octopus WL Tool</name>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Summary
- add explicit `<name>` in module POMs required by Maven Central validation:
  - `validation/pom.xml`
  - `wl-tool/pom.xml`

## Why
Recent release failed in Sonatype Central with `Project name is missing` for module artifacts.

## Validation
- `mvn -pl validation,wl-tool test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Maven module metadata by adding descriptive project names to validation and tool components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->